### PR TITLE
Updated/fixed information in top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage:
 ```
 gmetp.pl --cores 32 --cfg input.cfg
 ```
-Examples of input configuration files can be found at https://github.com/gatech-genemark/GeneMark-ETP-expi  
+Examples of input configuration files can be found at https://github.com/gatech-genemark/GeneMark-ETP-exp 
 
 ## Software license
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gene finding in eukaryotic genomes by GeneMark-ETP
 _GeneMark-ETP: Automatic Gene Finding in Eukaryotic Genomes in Consistence with Extrinsic Data_  
 Tomas Bruna, Alexandre Lomsadze, Mark Borodovsky  
 publication in preparation  
-[bioRxiv](https://www.biorxiv.org/content/10.1101/2023.01.13.524024v3)  
+[Genome research]([https://www.biorxiv.org/content/10.1101/2023.01.13.524024v3](https://genome.cshlp.org/content/34/5/757.full))  
 Georgia Institute of Technology, Atlanta, Georgia, USA  
 
 ## Experiments

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Gene finding in eukaryotic genomes by GeneMark-ETP
 ## Reference
 
 _GeneMark-ETP: Automatic Gene Finding in Eukaryotic Genomes in Consistence with Extrinsic Data_  
-Tomas Bruna, Alexandre Lomsadze, Mark Borodovsky  
-publication in preparation  
-[Genome research]([https://www.biorxiv.org/content/10.1101/2023.01.13.524024v3](https://genome.cshlp.org/content/34/5/757.full))  
+Tomas Bruna, Alexandre Lomsadze, Mark Borodovsky <br>
+[Genome Res. 2024. 34: 757-768](https://genome.cshlp.org/content/34/5/757.full)
+
 Georgia Institute of Technology, Atlanta, Georgia, USA  
 
 ## Experiments


### PR DESCRIPTION
I know this is a small change, but it replaces the BioArxiv link to the manuscript in preparation with the Genome Research article, and fixes a broken link farther down.